### PR TITLE
feat : make command calling drug news crawler

### DIFF
--- a/apps/data_collection/apps.py
+++ b/apps/data_collection/apps.py
@@ -1,6 +1,21 @@
+import logging
+import sys
+
 from django.apps import AppConfig
+from django.core.management import call_command
 
 
 class DataCollectionConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'apps.data_collection'
+
+    def ready(self):
+        """
+         runserver시 마약 뉴스 크롤링 커맨드를 수행
+        """
+        # only run during 'runserver' command
+        if 'runserver' not in sys.argv:
+            return
+
+        # FIXME HTTP 연결 실패
+        # call_command('crawldata')

--- a/drugstore/management/commands/crawldata.py
+++ b/drugstore/management/commands/crawldata.py
@@ -1,0 +1,20 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from apps.data_collection.models import *
+from apps.data_collection.views import save_articles, parse_article_to_word
+
+
+class Command(BaseCommand):
+    help = 'Crawl drug news data.'
+
+    def handle(self, *args, **options):
+        logging.info('delete words and article')
+        Word.objects.all().delete()
+        Article.objects.all().delete()
+
+        logging.info('run drug news crawler')
+        save_articles()
+        parse_article_to_word()
+
+        self.stdout.write(self.style.SUCCESS('Successfully loaded crawl data.'))


### PR DESCRIPTION
- 커맨드로 크롤러를 수행할 수 있도록 구현
- runserver 시 크롤링 커맨드를 수행할 경우 HTTP 연결 실패하는 이슈 존재해 주석처리


- http 연결 시도를 3회 시도하나 모두 실패해 발생하는 이슈같습니다
`WARNING:urllib3.connectionpool:Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<urllib3.connection.HTTPConnection object at 0x1253e33a0>: Failed to establish a new connection: [Errno 61] Connection refused')': /session/5c4070950b9accee3e12876b433bec1e
